### PR TITLE
Investigate deployment error in enhanced exam repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,15 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+# Exam Enhanced
+
+## Environment variables
+
+Set the following for correct auth behavior in all environments:
+
+- `NEXTAUTH_URL`: Must be the public URL. Use `https://...` in production so NextAuth sets the `__Secure-next-auth.session-token` cookie; use `http://localhost:3000` locally (non-secure).
+- `NEXTAUTH_SECRET`: A strong secret used by NextAuth/JWT decode.
+- `API`: Backend base URL the app calls.
+
+The app derives the cookie name automatically via `AUTH_COOKIE` from `NEXTAUTH_URL`. If `NEXTAUTH_URL` starts with `https://`, the cookie name is `__Secure-next-auth.session-token`; otherwise it is `next-auth.session-token`.

--- a/src/hooks/get-token.tsx
+++ b/src/hooks/get-token.tsx
@@ -1,11 +1,17 @@
 import { decode } from "next-auth/jwt";
 import { cookies } from "next/headers";
+import { AUTH_COOKIE, NEXTAUTHCOOCKIES } from "@/lib/types/constant";
 
 export default async function getUserToken() {
   // Get token
   try {
-    const tokenCookies = cookies().get(process.env.NEXTAUTHCOOCKIES as string)?.value;
-    const token = await decode({ token: tokenCookies, secret: process.env.NEXTAUTH_SECRET! });
+    // Prefer derived AUTH_COOKIE, fallback to env var name, then to default constant
+    const cookieName = AUTH_COOKIE || (process.env.NEXTAUTHCOOCKIES as string) || NEXTAUTHCOOCKIES;
+    const tokenCookies = cookies().get(cookieName)?.value;
+
+    if (!tokenCookies || !process.env.NEXTAUTH_SECRET) return undefined;
+
+    const token = await decode({ token: tokenCookies, secret: process.env.NEXTAUTH_SECRET });
 
     return token?.accessToken;
   } catch (error) {

--- a/src/lib/types/constant.ts
+++ b/src/lib/types/constant.ts
@@ -3,3 +3,9 @@ export const HEADER_CONTENT_TYPE = {
 };
 
 export const NEXTAUTHCOOCKIES = "next-auth.session-token";
+
+// Derive the correct NextAuth session cookie name based on protocol
+export const AUTH_COOKIE = (() => {
+  const isSecure = process.env.NEXTAUTH_URL?.startsWith("https://");
+  return isSecure ? "__Secure-next-auth.session-token" : "next-auth.session-token";
+})();


### PR DESCRIPTION
Introduce dynamic `AUTH_COOKIE` constant and update `getUserToken` to correctly retrieve NextAuth session tokens, resolving Server Components render errors in production.

The error occurred because `getUserToken` was attempting to retrieve the NextAuth session token using an incorrect cookie name. In production environments using HTTPS, NextAuth automatically prefixes the session cookie with `__Secure-`. The previous implementation failed to account for this, resulting in `cookies().get()` returning `undefined` and subsequently causing a hidden Server Components error. This PR ensures the correct cookie name is used based on the `NEXTAUTH_URL` protocol and adds robust checks for missing tokens or secrets.

---
<a href="https://cursor.com/background-agent?bcId=bc-78957993-6665-4f77-877c-959e685e2cba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-78957993-6665-4f77-877c-959e685e2cba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

